### PR TITLE
Add a couple of missing xml:id attributes to <msItem> nodes

### DIFF
--- a/.github/workflows/check_xml.py
+++ b/.github/workflows/check_xml.py
@@ -7,50 +7,35 @@ This doesn't mean it can be parsed and used in the catalogue pipeline
 by the Digital Engagement team, but it's a useful first pass.
 """
 
+import collections
 import os
 import subprocess
 import sys
+import textwrap
 from xml.etree import ElementTree as ET
 
+from validation_rules import (
+    check_for_author_names_with_no_original,
+    check_for_malformed_manuscript_ids,
+)
 
-RED   = "\033[1;31m"
+
+RED = "\033[1;31m"
 GREEN = "\033[0;32m"
 RESET = "\033[0;0m"
-BLUE  = "\033[1;34m"
+BLUE = "\033[1;34m"
 
 
 def get_file_paths_under(root=".", *, suffix=""):
     """Generates the paths to every file under ``root``."""
-    if not os.path.isdir(root):
-        raise ValueError(f"Cannot find files under non-existent directory: {root!r}")
-
     for dirpath, _, filenames in os.walk(root):
         for f in filenames:
             if os.path.isfile(os.path.join(dirpath, f)) and f.lower().endswith(suffix):
                 yield os.path.join(dirpath, f)
 
 
-def guess_line_label(path, text):
-    """
-    Given a file and some text, return a hint about where this text
-    might appear.
-    """
-    lines = enumerate(list(open(path)), start=1)
-
-    line_numbers = [lineno for lineno, line in lines if text in line]
-
-    if len(line_numbers) == 0:
-        return ""
-    else:
-        return (
-            f"(try looking at {BLUE}{text}{RESET} on "
-            + ", ".join(f"{BLUE}L{lineno}{RESET}" for lineno in line_numbers)
-            + ")"
-        )
-
-
-if __name__ == "__main__":
-    repo_root = (
+def get_repo_root():
+    return (
         subprocess.check_output(
             [
                 "git",
@@ -62,87 +47,47 @@ if __name__ == "__main__":
         .decode("ascii")
     )
 
-    errors = 0
+
+if __name__ == "__main__":
+    repo_root = get_repo_root()
+
+    errors = collections.defaultdict(list)
 
     for path in sorted(get_file_paths_under(repo_root, suffix=".xml")):
 
         # Exclude a couple of paths that aren't actual TEI files
-        if os.path.relpath(path, start=repo_root).startswith(("Templates/", "docs/")):
+        if os.path.relpath(path, start=repo_root).startswith(
+            ("Templates/", "docs/", "minimum-viable-records/")
+        ):
             continue
 
         try:
             root = ET.parse(path).getroot()
         except ET.ParseError as err:
-            print("")
-            print(os.path.relpath(path, start=repo_root))
-            print(f"\tUnable to parse XML: {err}")
-            errors += 1
+            errors[path].append(f"Unable to parse XML: {err}")
             continue
 
-        # The transformer expects to see author names in the form:
-        #
-        #       <author key="person_88345215">
-        #           <persName xml:lang="eng" type="standard">Badr-addin Muhammad b. Bahram b. Muhammad al-Qalanisi as-Samarqandi</persName>
-        #           <persName xml:lang="ar" type="original">بدر الدين محمد بن بهرام بن محمد القلانسي السمرقندي</persName>
-        #       </author>
-        #
-        # Notice that one is labelled `type="original"`; if this is missing,
-        # we don't know what contributor to display on the page.
-        for author in root.findall(".//{http://www.tei-c.org/ns/1.0}author"):
-            persname_nodes = author.findall("./{http://www.tei-c.org/ns/1.0}persName")
+        validation_rules = [
+            check_for_author_names_with_no_original,
+            check_for_malformed_manuscript_ids,
+        ]
 
-            if len(persname_nodes) <= 1:
-                continue
+        for run_rule in validation_rules:
+            for e in run_rule(root, path):
+                errors[path].append(e)
 
-            if not any(pn.attrib.get("type") == "original" for pn in persname_nodes):
-                line_label = guess_line_label(path, text=persname_nodes[0].text.splitlines()[0])
-
-                print("")
-                print(os.path.relpath(path, start=repo_root))
-                print(
-                    f'\tFound <author> with multiple <persName> nodes but no type="original"'
-                )
-                if line_label:
-                    print(f'\t{line_label}')
-                errors += 1
-
-        # We expect to see manuscript IDs in the form: 'MS $Language $Number',
-        # e.g. 'MS Hebrew B1' or 'MS Arabic 247'.
-        #
-        # This looks for the manuscript ID in <idno type="msID">, and warns
-        # if it's not as expected.
-        #
-        # We skip some special cases which are not currently handled by
-        # this rule and need more work to fix.
-        if "/Spanish/" in path or "/Indic/" in path or "/Greek/" in path:
-            continue
-
-        actual_manuscript_id = root.find(".//{http://www.tei-c.org/ns/1.0}idno[@type='msID']").text
-
-        language = os.path.basename(os.path.dirname(path))
-
-        # e.g. Hebrew_B_55.xml ~> B55, Tamil_49.xml ~> 49
-        if "/Hebrew/" in path:
-            ms_short_id = "".join(path.split(".")[0].rsplit("_")[-2:])
-        else:
-            ms_short_id = path.split("_")[-1].split(".")[0]
-
-        expected_manuscript_id = f"MS {language} {ms_short_id}"
-
-        if expected_manuscript_id != actual_manuscript_id:
-            print("")
-            print(os.path.relpath(path, start=repo_root))
-            print(f'\tManuscript ID in <idno type="msID"> is malformed:')
-            print(f'\t\tExpected: {GREEN}{expected_manuscript_id!r}{RESET}')
-            print(f'\t\tActual:   {RED}{actual_manuscript_id!r}{RESET}')
-            errors += 1
-
-    print("")
-
-    if errors == 0:
+    if not errors:
         print(f"{GREEN}🎉 All files checked, no errors!{RESET}")
     else:
+        for path, per_file_errors in sorted(errors.items()):
+            print("")
+            print(f"{BLUE}{os.path.relpath(path, repo_root)}{RESET}")
+            for e in per_file_errors:
+                print(textwrap.indent(e, prefix="\t"))
+
+        total_errors = sum(len(v) for v in errors.values())
+
         print(
-            f"{RED}⚠️ All files checked, {errors} error{'s' if errors > 0 else ''} found!{RESET}"
+            f"{RED}⚠️ All files checked, {total_errors} error{'s' if total_errors > 0 else ''} found!{RESET}"
         )
         sys.exit(1)

--- a/.github/workflows/validation_rules.py
+++ b/.github/workflows/validation_rules.py
@@ -1,0 +1,92 @@
+import os
+
+
+RED = "\033[1;31m"
+GREEN = "\033[0;32m"
+RESET = "\033[0;0m"
+
+
+def guess_line_label(path, text):
+    """
+    Given a file and some text, return a hint about where this text
+    might appear.
+    """
+    lines = enumerate(list(open(path)), start=1)
+
+    line_numbers = [lineno for lineno, line in lines if text in line]
+
+    if len(line_numbers) == 0:
+        return ""
+    else:
+        return (
+            f"(try looking at {BLUE}{text}{RESET} on "
+            + ", ".join(f"{BLUE}L{lineno}{RESET}" for lineno in line_numbers)
+            + ")"
+        )
+
+
+def check_for_author_names_with_no_original(root, path):
+    """
+    The front-end expects to see author names in the form:
+          <author key="person_88345215">
+              <persName xml:lang="eng" type="standard">Badr-addin Muhammad b. Bahram b. Muhammad al-Qalanisi as-Samarqandi</persName>
+              <persName xml:lang="ar" type="original">بدر الدين محمد بن بهرام بن محمد القلانسي السمرقندي</persName>
+          </author>
+
+    Notice that one is labelled `type="original"`; if this is missing,
+    we don't know what contributor to display on the page.
+    """
+    for author in root.findall(".//{http://www.tei-c.org/ns/1.0}author"):
+        persname_nodes = author.findall("./{http://www.tei-c.org/ns/1.0}persName")
+
+        if len(persname_nodes) <= 1:
+            continue
+
+        if not any(pn.attrib.get("type") == "original" for pn in persname_nodes):
+            message = (
+                'Found <author> with multiple <persName> nodes but no type="original"'
+            )
+            line_label = guess_line_label(
+                path, text=persname_nodes[0].text.splitlines()[0]
+            )
+
+            if line_label:
+                yield f"{message}\n{line_label}"
+            else:
+                yield message
+
+
+def check_for_malformed_manuscript_ids(root, path):
+    """
+    We expect to see manuscript IDs in the form: 'MS $Language $Number',
+    e.g. 'MS Hebrew B1' or 'MS Arabic 247'.
+
+    This looks for the manuscript ID in <idno type="msID">, and warns
+    if it's not as expected.
+
+    We skip some special cases which are not currently handled by
+    this rule and need more work to fix.
+    """
+    if not ("/Spanish/" in path or "/Indic/" in path or "/Greek/" in path):
+        actual_manuscript_id = root.find(
+            ".//{http://www.tei-c.org/ns/1.0}idno[@type='msID']"
+        ).text
+
+        language = os.path.basename(os.path.dirname(path))
+
+        # e.g. Hebrew_B_55.xml ~> B55, Tamil_49.xml ~> 49
+        if "/Hebrew/" in path:
+            ms_short_id = "".join(path.split(".")[0].rsplit("_")[-2:])
+        else:
+            ms_short_id = path.split("_")[-1].split(".")[0]
+
+        expected_manuscript_id = f"MS {language} {ms_short_id}"
+
+        if expected_manuscript_id != actual_manuscript_id:
+            yield "\n".join(
+                [
+                    f'Manuscript ID in <idno type="msID"> is malformed:',
+                    f"\tExpected: {GREEN}{expected_manuscript_id!r}{RESET}",
+                    f"\tActual:   {RED}{actual_manuscript_id!r}{RESET}",
+                ]
+            )

--- a/Arabic/MS_Arabic_414.xml
+++ b/Arabic/MS_Arabic_414.xml
@@ -147,7 +147,7 @@
                           
                         <textLang mainLang="ar">Arabic</textLang>
                           
-                        <msItem>
+                        <msItem xml:id="WMS_Arabic_414_part1-item1">
                             
                             <author key="person_ 89770781">
                                 <persName xml:lang="eng" type="standard">Avicenna, 980-1037</persName>
@@ -205,7 +205,7 @@
                             </summary>
                             
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_414_part2-item1">
                                 <author xml:lang="en" >Anonymous</author>
                                 
                                 <title xml:lang="ar-Latn-x-lc">Bayān Māhiyat Tašrīḥ-i Badān</title>

--- a/Arabic/MS_Arabic_439.xml
+++ b/Arabic/MS_Arabic_439.xml
@@ -153,7 +153,7 @@
                           
                         <textLang mainLang="ar">Arabic</textLang>
                           
-                        <msItem>
+                        <msItem xml:id="WMS_Arabic_439_part1-item1">
                             
                             <author key="person_ 9664480">
                                 <persName xml:lang="eng" type="standard">Yūsuf  Ismā`īl b. Ilyās al-H̱uwayī al-Kutubī </persName>
@@ -227,7 +227,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_439_part2-item1">
                                 
                                 <author>Anonymous</author>
                                 
@@ -267,7 +267,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_439_part3-item1">
                                 <author>Anonymous</author>
                                 
                                 <title xml:lang="ar-Latn-x-lc" type="standard">Al-Bāb 21 fī Šarḥ Asmā' al-Adwiyat al-mufradat</title>
@@ -305,7 +305,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_439_part4-item1">
                                 <author>Anonymous</author>
                                 
                                 <title xml:lang="ar-Latn-x-lc" type="standard">Al-Bāb 22 fī al-Awzān wa-l-Makāyīl</title>
@@ -339,7 +339,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_439_part5-item1">
                                 <author>Anonymous</author>
                                 
                                 <title xml:lang="ar-Latn-x-lc" type="standard">Al-Bāb 23 fī Waṣāyā yantafa`a bi-hā</title>
@@ -375,7 +375,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_439_part6-item1">
                                 <author>Anonymous</author>
                                 
                                 <title xml:lang="ar-Latn-x-lc" type="standard">Al-Bāb 24 fī Kayfiyat Ittiẖāḏ al-Adwiyat
@@ -387,7 +387,7 @@
                                 <incipit>
                                     <locus>Fol. 126b.24</locus>
                                     ال‍باب ال‍رابع وال‍عشرون في كيفية اتخاذ الادوية ال‍مفرده في اي زمان
-                                    ومن اي مكان و‌في اي الاشيا تخزن و‌ما  يفسدها و‌ما يصلحها و‌يعتمد عليه
+                                    ومن اي مكان و‌في اي الا شيا تخزن و‌ما  يفسدها و‌ما يصلحها و‌يعتمد عليه
                                     و‌ما يعمل مع بعض الادوية ال‍مفرده مما يمنع فسادها
                                 </incipit>
                                 
@@ -413,7 +413,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_439_part7-item1">
                                 <author>Anonymous</author>
                                 
                                 <title xml:lang="ar-Latn-x-lc" type="standard">Al-Bāb 25 fī Imtiḥān

--- a/Arabic/MS_Arabic_451.xml
+++ b/Arabic/MS_Arabic_451.xml
@@ -141,7 +141,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_451-part1-item1">
                                 
                                 <author>Anonymous</author>
                                 <title xml:lang="ar-Latn-x-lc" type="standard">Risālat fī l-`Ilāǧ kutibat li-l-Amīr Darwīš</title>
@@ -201,7 +201,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_451-part2-item1">
                                 
                                 <author>Anonymous
                                 </author>
@@ -241,7 +241,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_451-part3-item1">
                                 
                                 <author key="person_90075818">
                                     <persName xml:lang="eng" type="original">داوود بن عمر الانطاكى</persName>
@@ -282,7 +282,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_451-part4-item1">
                                 
                                 <author>
                                     <persName xml:lang="eng">Anonymous</persName>
@@ -327,7 +327,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_451-part5-item1">
                                 
                                 <author>Anonymous
                                 </author>
@@ -377,7 +377,7 @@
                             
                             <textLang mainLang="ar">Arabic</textLang>
                             
-                            <msItem>
+                            <msItem xml:id="WMS_Arabic_451-part6-item1">
                                 
                                 <author>
                                     <persName xml:lang="eng" type="standard">Abū

--- a/Arabic/MS_Arabic_797.xml
+++ b/Arabic/MS_Arabic_797.xml
@@ -32,7 +32,7 @@
           <msContents>
             <summary>1 copy of Ḥāshiyat Nafīsī by Ṣādiq ʻAlī Khān, Ḥakīm Muḥammad,‏ ‎d.
               1771-1848</summary>
-            <msItem>
+            <msItem xml:id="WMS_Arabic_797-item1" n="1">
               <locus facs="#i0006 #i0325"/>
 
               <author key="person_143146462581927770449">

--- a/Arabic/MS_Arabic_816.xml
+++ b/Arabic/MS_Arabic_816.xml
@@ -31,7 +31,7 @@
 
           <msContents>
             <summary>1 anonymous treatise on geomancy</summary>
-            <msItem>
+            <msItem xml:id="WMS_Arabic_816-item1">
               <locus facs="#i0002 #i0014"/>
               <author key="person_f407">
                 <persName xml:lang="en">Anonymous</persName>

--- a/Arabic/MS_Arabic_831.xml
+++ b/Arabic/MS_Arabic_831.xml
@@ -32,7 +32,7 @@
           <msContents>
             <summary>1 copy of al-Shamsīyah fī al-aʿmāl al-jaybīyah by Ṣūfī, Muḥammad ibn Abī al-Fatḥ,‏ ‎d.
               -1543 </summary>
-            <msItem>
+            <msItem xml:id="WMS_Arabic_831-item1">
               <locus facs="#i0003 #i0008"/>
               <author key="person_172514598">
                 <persName xml:lang="ar-Latn-x-lc" type="standard">Ṣūfī, Muḥammad ibn Abī al-Fatḥ,‏ ‎d.

--- a/Arabic/MS_Arabic_870.xml
+++ b/Arabic/MS_Arabic_870.xml
@@ -148,7 +148,7 @@
 
                             <textLang mainLang="ar">Arabic</textLang>
                         </msItem>
-                        <msItem>
+                        <msItem xml:id="MS_Arabic_870-item5" n="5">
                             <locus facs="#i0032 #i0044">ff. 32r-43v</locus>
                             <author>
                                 <persName xml:lang="en">Anonymous</persName>
@@ -157,7 +157,7 @@
                             <textLang mainLang="ar">Arabic</textLang>
                         </msItem>
 
-                        <msItem xml:id="MS_Arabic_870-item5" n="5">
+                        <msItem xml:id="MS_Arabic_870-item6" n="6">
 
 
                             <locus facs="#i0044 #i0083">ff. 44r-83r</locus>
@@ -185,7 +185,7 @@
 
                             <textLang mainLang="ar">Arabic</textLang>
                         </msItem>
-                        <msItem xml:id="MS_Arabic_870-item6" n="6">
+                        <msItem xml:id="MS_Arabic_870-item7" n="7">
                             <locus facs="#i0047 #i0049">ff. 46v-48v</locus>
                             <author>
                                 <persName xml:lang="en">Anonymous</persName>


### PR DESCRIPTION
This attribute is how we identify parts of a manuscript in the front-end, and they're used to create the identifiers that go in works URLs (e.g. /works/qxvg3rvp)

The front-end is warning that these attributes are missing, so I've added them; this should allow these manuscripts to appear online.

(Plus some fixes to the XML checker that you can ignore.)